### PR TITLE
fix order of inky

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -35,12 +35,12 @@ function clean(done) {
 // Then parse using Inky templates
 function pages() {
   return gulp.src('src/pages/**/*.html')
-    .pipe(inky())
     .pipe(panini({
       root: 'src/pages',
       layouts: 'src/layouts',
       partials: 'src/partials'
     }))
+    .pipe(inky())
     .pipe(gulp.dest('dist'));
 }
 


### PR DESCRIPTION
I wondered why all my handlebar templates didn't work, where I used partials and helpers.
with a syntax like `{{> footer}}` or `{{myHelper "foobar"}}`

The errors shows me that some characters were (html)escaped, like `>` and `"`
Anyway it looks like a mistake that inky is processed before handlebars.