### PR TITLE
Add repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "foundation-emails-template",
   "version": "1.0.0",
   "description": "Basic template for a Foundation for Emails project.",
+  "repository": "zurb/foundation-emails-template",
   "main": "gulpfile.babel.js",
   "scripts": {
     "start": "gulp",


### PR DESCRIPTION
Currently when doing an install with this as a dependency, npm throws a warning of "npm WARN package.json foundation-emails-template@1.0.0 No repository field."

While minor, this is a quick and easy fix per the spec here: https://docs.npmjs.com/files/package.json#repository

I've used the shortcut syntax, but here is the json for the expanded version, if that is preferred:

```
"repository" :
  { "type" : "git"
  , "url" : "https://github.com/zurb/foundation-emails-template.git"
  }
```