### PR TITLE
Missnamed variable in _settings.scss build fail

### DIFF
--- a/src/assets/scss/_settings.scss
+++ b/src/assets/scss/_settings.scss
@@ -31,7 +31,7 @@ $global-width: 580px;
 $global-width-small: 95%;
 $global-gutter: 16px;
 $body-background: $light-gray;
-$container-background: $white;
+$container-background-color: $white;
 $global-font-color: $black;
 $body-font-family: Helvetica, Arial, sans-serif;
 $global-padding: 16px;


### PR DESCRIPTION
After update to foundation-emails 2.0.0-rc.3 the variabled
$container-background-color was changed to $container-background which
caused sass build to fail.