### PR TITLE
Fix for issue #297 - Adds HTTPS support to the gulp 4.0 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "babel-core": "^6.3.26",
     "babel-preset-es2015": "^6.3.13",
     "browser-sync": "^2.11.0",
-    "gulp": "git://github.com/gulpjs/gulp.git#4.0",
+    "gulp": "git+https://github.com/gulpjs/gulp.git#4.0",
     "gulp-cli": "^1.1.0",
     "gulp-htmlmin": "^1.1.1",
     "gulp-if": "^2.0.0",


### PR DESCRIPTION
This change adds HTTPS support to the gulp 4.0 dependency.

https://github.com/zurb/foundation-emails/issues/297