### PR TITLE
Update panini and foundation-emails dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "ZURB <foundation@zurb.com>",
   "license": "MIT",
   "dependencies": {
-    "foundation-emails": "2.0.0"
+    "foundation-emails": "2.0.1"
   },
   "devDependencies": {
     "babel-core": "^6.3.26",
@@ -29,7 +29,7 @@
     "gulp-sourcemaps": "^1.6.0",
     "inky": "^1.3.3",
     "lazypipe": "^1.0.1",
-    "panini": "^1.2.0",
+    "panini": "^1.3.0",
     "rimraf": "^2.3.3",
     "siphon-media-query": "^1.0.0",
     "yargs": "^4.1.0"


### PR DESCRIPTION
Bump versions of dependencies: 

- panini to get Handlebars v4 
- foundation-emails for fix of expanded buttons not working in Outlook 2007, 2010, and 2013