### PR TITLE
Add missing tbody

### DIFF
--- a/src/layouts/default.html
+++ b/src/layouts/default.html
@@ -14,14 +14,16 @@
     <!-- <style> -->
     <span class="preheader">{{description}}</span>
     <table class="body">
-      <tr>
-        <td class="center" align="center" valign="top">
-          <center>
-            {{!-- Pages you create in the src/pages/ folder are inserted here when the flattened emails are created. --}}
-            {{> body}}
-          </center>
-        </td>
-      </tr>
+      <tbody>
+        <tr>
+          <td class="center" align="center" valign="top">
+            <center>
+              {{!-- Pages you create in the src/pages/ folder are inserted here when the flattened emails are created. --}}
+              {{> body}}
+            </center>
+          </td>
+        </tr>
+      </tbody>
     </table>
     <!-- prevent Gmail on iOS font size manipulation -->
    <div style="display:none; white-space:nowrap; font:15px courier; line-height:0;"> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </div>


### PR DESCRIPTION
_See https://github.com/zurb/inky/pull/59._

> Rendering the HTML Output inside a `react` component would throw a warning.
```
warning.js?8a56:44 Warning: validateDOMNesting(...): <tr> cannot appear as a child of <table>. See StatelessComponent > table > tr. Add a <tbody> to your code to match the DOM tree generated by the browser.
```