### PR TITLE
remove redundant babel config

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,5 @@
     "rimraf": "^2.3.3",
     "siphon-media-query": "^1.0.0",
     "yargs": "^4.1.0"
-  },
-  "babel": {
-    "presets": ["es2015"]
   }
-
 }


### PR DESCRIPTION
This is confusing and potentially an area for conflicting configurations since it already exists in `.babelrc`