### PR TITLE
Missed parameter to gulp

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "gulpfile.babel.js",
   "scripts": {
     "start": "gulp",
-    "build": "gulp --production",
+    "build": "gulp build --production",
     "zip": "gulp zip --production",
     "litmus": "gulp litmus --production"
   },


### PR DESCRIPTION
It seems that the `npm run build` command should build the packet instead of launch the server.