### PR TITLE
Remove link to css file after inlining styles

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -116,6 +116,7 @@ function inliner(css) {
       removeLinkTags: false
     })
     .pipe($.replace, '<!-- <style> -->', `<style>${mqCss}</style>`)
+    .pipe($.replace, '<link rel="stylesheet" type="text/css" href="css/app.css">', '')
     .pipe($.htmlmin, {
       collapseWhitespace: true,
       minifyCSS: true


### PR DESCRIPTION
Fixes https://github.com/zurb/foundation-emails/issues/544 if you agree that the css file is not needed anymore