### PR TITLE
Master

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -65,7 +65,7 @@ function resetPages(done) {
 
 // Compile Sass into CSS
 function sass() {
-  return gulp.src('src/assets/scss/app.scss')
+  return gulp.src('src/assets/scss/app*.scss')
     .pipe($.if(!PRODUCTION, $.sourcemaps.init()))
     .pipe($.sass({
       includePaths: ['node_modules/foundation-emails/scss']


### PR DESCRIPTION
allows for layouts to have different css references but page names
prefix must match css file name
e.g.
> scss/__invite.scss
.invite { background-color:#333333; ... }
...

> scss/invite.scss
@import 'settings';
@import 'foundation-emails';
@import '_invite';
...

> layouts/invite.html
...
<link rel="stylesheet" type="text/css" href="css/invite.css">
...

> pages/invite.html, invite2.html, invite_audience1.html
---
layout: invite
---
...

So all the pages with the prefix "invite" will be inlined with the css
from invite.css