### PR TITLE
Updates Gmail font-size fix now that gmail supports inline 'display: none' declarations

### DIFF
--- a/src/layouts/default.html
+++ b/src/layouts/default.html
@@ -24,7 +24,8 @@
       </tr>
     </table>
     <!-- prevent Gmail on iOS font size manipulation -->
-   <div class="gmailfix" style="white-space:nowrap; font:15px courier; line-height:0;"> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </div>
+    <style>.gmailfix { display:none; display:none!important; }</style>
+    <div class="gmailfix" style="white-space:nowrap; font:15px courier; line-height:0;"> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </div>
   </body>
 </html>
 

--- a/src/layouts/default.html
+++ b/src/layouts/default.html
@@ -24,7 +24,7 @@
       </tr>
     </table>
     <!-- prevent Gmail on iOS font size manipulation -->
-   <div style="display:none; white-space:nowrap; font:15px courier; line-height:0;"> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </div>
+   <div class="gmailfix" style="white-space:nowrap; font:15px courier; line-height:0;"> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </div>
   </body>
 </html>
 


### PR DESCRIPTION
Gmail now supports `display: none;` when used inline:
https://www.emailonacid.com/blog/article/email-development/gmail-now-supports-display-none

Which means the `&nbsp;` [hack to prevent font-resizing](https://www.emailonacid.com/blog/article/email-development/android_gmail_app_and_inbox_app_still_increasing_font_size) no longer works. 

I've updated the relevant line in the template to remove `display: none;` from the inline styles and added a class 'gmailfix' that can be added to the main stylesheet. I supposed this would have to be in a media query so it doesn't get inlined:

All credit goes to Email on Acid blog and http://freshinbox.com/blog/gmail-supports-displaynone-and-gmail-ios-font-fix-update/
