### PR TITLE
On zip, the archived images follow their initial folder structure

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -195,7 +195,7 @@ function zip() {
     var moveImages = gulp.src(sourcePath)
       .pipe($.htmlSrc({ selector: 'img'}))
       .pipe($.rename(function (path) {
-        path.dirname = fileName + '/assets/img';
+        path.dirname = fileName + '/' + path.dirname;
         return path;
       }));
 


### PR DESCRIPTION
## Example:

Le't say I have the following assets/img folder structure to organize my images:

assets
-/ img
--/ changing
--/ static

If I run `npm run zip` or any other command that would trigger the _'zip'_ process, then by default,  inside the created archive, the images are all transferred to the /assets/img folder. This breaks the email because the image links inside the HTML are not changed.
## Solution:

Changing the default `fileName + '/assets/img'` value of **path.dirname** to:
 `fileName + '/' + path.dirname`
