### PR TITLE
Cleaner solution to remove link to css file after inlining styles

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -113,10 +113,10 @@ function inliner(css) {
     .pipe($.inlineCss, {
       applyStyleTags: false,
       removeStyleTags: false,
-      removeLinkTags: false
+      applyLinkTags: true,
+      removeLinkTags: true
     })
     .pipe($.replace, '<!-- <style> -->', `<style>${mqCss}</style>`)
-    .pipe($.replace, '<link rel="stylesheet" type="text/css" href="css/app.css">', '')
     .pipe($.htmlmin, {
       collapseWhitespace: true,
       minifyCSS: true


### PR DESCRIPTION
As [suggested by @leschirmeur](https://github.com/zurb/foundation-emails-template/pull/23#issuecomment-246099713) this is a cleaner solution than #23 .

`removeLinkTags: true` replaces the `.pipe($.replace, '<link rel="stylesheet"...` line.
I added `applyLinkTags: true` for completeness. It was previously not set but the default was `true` anyway.