### PR TITLE
Watch task: listen for all events

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -98,10 +98,10 @@ function server(done) {
 
 // Watch for file changes
 function watch() {
-  gulp.watch('src/pages/**/*.html').on('change', gulp.series(pages, inline, browser.reload));
-  gulp.watch(['src/layouts/**/*', 'src/partials/**/*']).on('change', gulp.series(resetPages, pages, inline, browser.reload));
-  gulp.watch(['../scss/**/*.scss', 'src/assets/scss/**/*.scss']).on('change', gulp.series(resetPages, sass, pages, inline, browser.reload));
-  gulp.watch('src/assets/img/**/*').on('change', gulp.series(images, browser.reload));
+  gulp.watch('src/pages/**/*.html').on('all', gulp.series(pages, inline, browser.reload));
+  gulp.watch(['src/layouts/**/*', 'src/partials/**/*']).on('all', gulp.series(resetPages, pages, inline, browser.reload));
+  gulp.watch(['../scss/**/*.scss', 'src/assets/scss/**/*.scss']).on('all', gulp.series(resetPages, sass, pages, inline, browser.reload));
+  gulp.watch('src/assets/img/**/*').on('all', gulp.series(images, browser.reload));
 }
 
 // Inlines CSS into HTML, adds media query CSS into the <style> tag of the email, and compresses the HTML


### PR DESCRIPTION
Since we're using Gulp 4, which uses [chokidar](https://github.com/paulmillr/chokidar) under the hood to watch files, we can switch from listening only the `'change'` event to listen for `'all'` events in `gulp.watch`.
This will make file addition/removal easier since we will no longer need to restart the gulp task to take those files into consideration.

From [chokidar's documentation about events](https://github.com/paulmillr/chokidar#methods--events):

> .on(event, callback): Listen for an FS event. Available events: add, addDir, change, unlink, unlinkDir, ready, raw, error. Additionally all is available which gets emitted with the underlying event name and path for every event other than ready, raw, and error.

Tested locally without issues.
