### PR TITLE
Remove Gmail hack for font size manipulation

### DIFF
--- a/src/layouts/default.html
+++ b/src/layouts/default.html
@@ -23,8 +23,6 @@
         </td>
       </tr>
     </table>
-    <!-- prevent Gmail on iOS font size manipulation -->
-   <div style="display:none; white-space:nowrap; font:15px courier; line-height:0;"> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </div>
   </body>
 </html>
 


### PR DESCRIPTION
The hack to avoid Gmail from resizing text size no longer works: http://freshinbox.com/blog/gmail-supports-displaynone-and-gmail-ios-font-fix-update/

