### PR TITLE
fix images path after zip task

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -219,7 +219,7 @@ function zip() {
     var moveImages = gulp.src(sourcePath)
       .pipe($.htmlSrc({ selector: 'img'}))
       .pipe($.rename(function (path) {
-        path.dirname = fileName + '/' + path.dirname;
+        path.dirname = fileName + path.dirname.replace('dist', '');
         return path;
       }));
 


### PR DESCRIPTION
After zip task completed *.zip file have this structure:
- test.zip
  - test.html
  - dist
    - assets
      - img
which is incorrect because links in test.html refer to assets directory