### PR TITLE
Curious as to why doing "@copywrite"

### DIFF
--- a/src/pages/marketing.html
+++ b/src/pages/marketing.html
@@ -62,8 +62,8 @@ subject: My Marketing Email Template Subject
   <row class="collapsed footer">
     <columns>
       <spacer size="16"></spacer>
-      <p class="text-center">@copywrite nobody<br/>
-      <a href="#">hello@nocopywrite.com</a> | <a href="#">Manage Email Notifications</a> | <a href="#">Unsubscribe</a></p>
+      <p class="text-center">&copy; copyright nobody<br/>
+      <a href="#">hello@nocopyright.com</a> | <a href="#">Manage Email Notifications</a> | <a href="#">Unsubscribe</a></p>
       <center>
         <menu>
           <item><img src="http://placehold.it/25" alt=""></item>


### PR DESCRIPTION
Versus more standard "&copy; copyright". 

I realize these are just templates and I'm likely over-analyzing, just stuck out to me. Seems to make it more recognizable/standard/fluid for users grabbing these templates.

Can go through and change others, if desired.