### PR TITLE
Gmail css fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "gulp-htmlmin": "^1.1.1",
     "gulp-if": "^2.0.0",
     "gulp-imagemin": "^2.4.0",
+    "gulp-inject": "^4.2.0",
     "gulp-inline-css": "^3.0.0",
     "gulp-litmus": "0.0.7",
     "gulp-load-plugins": "^1.1.0",

--- a/src/extras/gmail-hack.html
+++ b/src/extras/gmail-hack.html
@@ -1,0 +1,5 @@
+<style>
+  u + .body .gmail {
+    display: block !important;
+  }
+</style>

--- a/src/layouts/default.html
+++ b/src/layouts/default.html
@@ -10,6 +10,7 @@
     <meta name="viewport" content="width=device-width">
     <title>{{subject}}</title>
     <!-- <style> -->
+    <!-- inject:extras --><!-- endinject -->
   </head>
   <body>
     <span class="preheader">{{description}}</span>
@@ -24,7 +25,7 @@
       </tr>
     </table>
     <!-- prevent Gmail on iOS font size manipulation -->
-   <div style="display:none; white-space:nowrap; font:15px courier; line-height:0;"> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </div>
+   <div class="gmail" style="display:none; white-space:nowrap; font:15px courier; line-height:0;"> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </div>
   </body>
 </html>
 

--- a/src/layouts/index-layout.html
+++ b/src/layouts/index-layout.html
@@ -10,6 +10,7 @@
   <meta name="viewport" content="width=device-width">
   <title>{{subject}}</title>
   <!-- <style> -->
+  <!-- inject:extras --><!-- endinject -->
 </head>
 <body>
   <span class="preheader">{{description}}</span>
@@ -25,7 +26,7 @@
     </tr>
   </table>
   <!-- prevent Gmail on iOS font size manipulation -->
-  <div style="display:none; white-space:nowrap; font:15px courier; line-height:0;"> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </div>
+  <div class="gmail" style="display:none; white-space:nowrap; font:15px courier; line-height:0;"> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </div>
 </body>
 </html>
 


### PR DESCRIPTION
I found an issue where the gmail iOS font size section was never being display and so not having the desired affect.

The inliner was then stripping my custom CSS added to the head, and wrapping the code in a media query also had no effect.

To compensate, I've included the ability to inject 'extras' to the head _after_ the inliner in order to include the Gmail (or any other) custom contents from the `src/extras` folder.