### PR TITLE
Add litmus arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Run `npm run litmus` to build as above, then submit to litmus for testing. *AWS 
 
 Run `npm run mail` to build as above, then send to specified email address for testing. *SMTP server details required (config.json)*
 
-Run `npm run zip` to build as above, then zip HTML and images for easy deployment to email marketing services. 
+Run `npm run zip` to build as above, then zip HTML and images for easy deployment to email marketing services.
 
 ### Speeding Up Your Build
 
@@ -70,6 +70,8 @@ are inside the archive folder.
 ## Litmus Tests (config.json)
 
 Testing in Litmus requires the images to be hosted publicly. The provided gulp task handles this by automating hosting to an AWS S3 account. Provide your Litmus and AWS S3 account details in the `example.config.json` and then rename to `config.json`. Litmus config, and `aws.url` are required, however if you follow the [aws-sdk suggestions](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html) you don't need to supply the AWS credentials into this JSON.
+
+You will need to specify what template to test. Add the eamil/page name as a parameter like so: `npm run litmus -- --temp="basic"`.
 
 ```json
 {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -18,6 +18,7 @@ const $ = plugins();
 // Look for the --production flag
 const PRODUCTION = !!(yargs.argv.production);
 const EMAIL = yargs.argv.to;
+const TEMP = yargs.argv.temp;
 
 // Declar var so that both AWS and Litmus task can use it.
 var CONFIG;
@@ -170,7 +171,13 @@ function aws() {
 function litmus() {
   var awsURL = !!CONFIG && !!CONFIG.aws && !!CONFIG.aws.url ? CONFIG.aws.url : false;
 
-  return gulp.src('dist/**/*.html')
+  if(!TEMP) {
+    beep();
+    console.log('[Litmus]'.bold.red + ' You are missing parameters. Please see README.md');
+    process.exit();
+  }
+
+  return gulp.src('dist/**/' + TEMP + '.html')
     .pipe($.if(!!awsURL, $.replace(/=('|")(\/?assets\/img)/g, "=$1"+ awsURL)))
     .pipe($.litmus(CONFIG.litmus))
     .pipe(gulp.dest('dist'));


### PR DESCRIPTION
Adds a parameter to specify a single template to generate a Litmus test for. It is typically not desirable to generate a test for all templates every time.

When you are ready to create a Litmus test run the following command:
`npm run litmus -- --temp="basic"`