### PR TITLE
Update gulp to work with node v16

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -11,7 +11,8 @@ import siphon   from 'siphon-media-query';
 import path     from 'path';
 import merge    from 'merge-stream';
 import beep     from 'beepbeep';
-import colors   from 'colors';
+
+const sass = require('gulp-sass')(require('sass'));
 
 const $ = plugins();
 
@@ -24,7 +25,7 @@ var CONFIG;
 
 // Build the "dist" folder by running all of the below tasks
 gulp.task('build',
-  gulp.series(clean, pages, sass, images, inline));
+  gulp.series(clean, pages, sass2css, images, inline));
 
 // Build emails, run the server, and watch for file changes
 gulp.task('default',
@@ -69,12 +70,12 @@ function resetPages(done) {
 }
 
 // Compile Sass into CSS
-function sass() {
+function sass2css() {
   return gulp.src('src/assets/scss/app.scss')
     .pipe($.if(!PRODUCTION, $.sourcemaps.init()))
-    .pipe($.sass({
+    .pipe(sass({
       includePaths: ['node_modules/foundation-emails/scss']
-    }).on('error', $.sass.logError))
+    }).on('error', sass.logError))
     .pipe($.if(PRODUCTION, $.uncss(
       {
         html: ['dist/**/*.html']
@@ -109,7 +110,7 @@ function server(done) {
 function watch() {
   gulp.watch('src/pages/**/*.html').on('all', gulp.series(pages, inline, browser.reload));
   gulp.watch(['src/layouts/**/*', 'src/partials/**/*']).on('all', gulp.series(resetPages, pages, inline, browser.reload));
-  gulp.watch(['../scss/**/*.scss', 'src/assets/scss/**/*.scss']).on('all', gulp.series(resetPages, sass, pages, inline, browser.reload));
+  gulp.watch(['../scss/**/*.scss', 'src/assets/scss/**/*.scss']).on('all', gulp.series(resetPages, sass2css, pages, inline, browser.reload));
   gulp.watch('src/assets/img/**/*').on('all', gulp.series(images, browser.reload));
 }
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "gulp-mail": "^0.1.1",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",
-    "gulp-sass": "^3.1.0",
+    "gulp-sass": "^5.1.0",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uncss": "^1.0.1",
     "gulp-zip": "^3.2.0",
@@ -45,6 +45,7 @@
     "merge-stream": "^1.0.0",
     "panini": "^1.3.0",
     "rimraf": "^2.3.3",
+    "sass": "^1.49.9",
     "siphon-media-query": "^1.0.0",
     "yargs": "^4.1.0"
   },


### PR DESCRIPTION
This allows using the template, as-is, using the latest LTS version of node.